### PR TITLE
NP-10 NetBeans plugin JDK 11 support

### DIFF
--- a/payara.common/src/sun/util/logging/resources/logging.properties
+++ b/payara.common/src/sun/util/logging/resources/logging.properties
@@ -1,0 +1,46 @@
+#
+# Copyright (c) 2001, 2013, Oracle and/or its affiliates. All rights reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.  Oracle designates this
+# particular file as subject to the "Classpath" exception as provided
+# by Oracle in the LICENSE file that accompanied this code.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+# or visit www.oracle.com if you need additional information or have any
+# questions.
+#
+
+# Localizations for Level names.  For the US locale
+# these are the same as the non-localized level name.
+
+# The following ALL CAPS words should be translated.
+ALL=All
+# The following ALL CAPS words should be translated.
+SEVERE=Severe
+# The following ALL CAPS words should be translated.
+WARNING=Warning
+# The following ALL CAPS words should be translated.
+INFO=Info
+# The following ALL CAPS words should be translated.
+CONFIG= Config
+# The following ALL CAPS words should be translated.
+FINE=Fine
+# The following ALL CAPS words should be translated.
+FINER=Finer
+# The following ALL CAPS words should be translated.
+FINEST=Finest
+# The following ALL CAPS words should be translated.
+OFF=Off

--- a/payara.tooling/nbproject/project.xml
+++ b/payara.tooling/nbproject/project.xml
@@ -25,6 +25,15 @@
                     </run-dependency>
                 </dependency>
                 <dependency>
+                    <code-name-base>org.netbeans.modules.xml.jaxb.api</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <release-version>1</release-version>
+                        <specification-version>1.29.1</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
                     <code-name-base>org.openide.util</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>

--- a/payara.tooling/src/org/netbeans/modules/payara/tooling/data/StartupArgs.java
+++ b/payara.tooling/src/org/netbeans/modules/payara/tooling/data/StartupArgs.java
@@ -37,12 +37,13 @@
  *
  * Contributor(s):
  */
-// Portions Copyright [2017] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2017-2019] [Payara Foundation and/or its affiliates]
 
 package org.netbeans.modules.payara.tooling.data;
 
 import java.util.List;
 import java.util.Map;
+import org.netbeans.modules.payara.tooling.server.JDK.Version;
 
 /**
  * This interface provides IDE and user specific arguments for starting the server.
@@ -58,5 +59,7 @@ public interface StartupArgs {
     public Map<String, String> getEnvironmentVars();
 
     public String getJavaHome();
+
+    public Version getJavaVersion();
 
 }

--- a/payara.tooling/src/org/netbeans/modules/payara/tooling/data/StartupArgsEntity.java
+++ b/payara.tooling/src/org/netbeans/modules/payara/tooling/data/StartupArgsEntity.java
@@ -37,12 +37,19 @@
  *
  * Contributor(s):
  */
-// Portions Copyright [2017] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2017-2019] [Payara Foundation and/or its affiliates]
 
 package org.netbeans.modules.payara.tooling.data;
 
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import org.netbeans.modules.payara.tooling.server.JDK;
+import org.netbeans.modules.payara.tooling.server.JDK.Version;
+import org.openide.util.Exceptions;
 
 /**
  * Payara Server Entity.
@@ -68,6 +75,9 @@ public class StartupArgsEntity implements StartupArgs {
 
     /** Installation home of Java SDK used to run Payara. */
     private String javaHome;
+
+    /** Version of Java SDK used to run Payara. */
+    private Version javaVersion;
 
     ////////////////////////////////////////////////////////////////////////////
     // Constructors                                                           //
@@ -174,6 +184,25 @@ public class StartupArgsEntity implements StartupArgs {
      */
     public void getJavaHome(String javaHome) {
         this.javaHome = javaHome;
+    }
+
+    /**
+     * Get version of Java SDK used to run Payara.
+     * <p/>
+     * @return version of Java SDK used to run Payara.
+     */
+    @Override
+    public Version getJavaVersion() {
+        if(javaVersion == null && javaHome != null) {
+            try (BufferedReader bufferedReader
+                    = new BufferedReader(new FileReader(new File(javaHome, "release")));) {
+                String version = bufferedReader.readLine();
+                javaVersion = JDK.getVersion(version.substring(version.indexOf("\"") + 1, version.lastIndexOf("\"")));
+            } catch (IOException ex) {
+                Exceptions.printStackTrace(ex);
+            }
+        }
+        return javaVersion;
     }
 
 }

--- a/payara.tooling/src/org/netbeans/modules/payara/tooling/server/JDK.java
+++ b/payara.tooling/src/org/netbeans/modules/payara/tooling/server/JDK.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2018] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2018-2019] [Payara Foundation and/or its affiliates]
 
 package org.netbeans.modules.payara.tooling.server;
 
@@ -239,15 +239,19 @@ public final class JDK {
         return new Version();
     }
 
-    public static boolean isCorrectJDK(Optional<Version> minVersion, Optional<Version> maxVersion) {
+    public static boolean isCorrectJDK(Version jdkVersion, Optional<Version> minVersion, Optional<Version> maxVersion) {
         boolean correctJDK = true;
         if (minVersion.isPresent()) {
-            correctJDK = JDK_VERSION.newerOrEquals(minVersion.get());
+            correctJDK = jdkVersion.newerOrEquals(minVersion.get());
         }
         if (correctJDK && maxVersion.isPresent()) {
-            correctJDK = JDK_VERSION.olderOrEquals(maxVersion.get());
+            correctJDK = jdkVersion.olderOrEquals(maxVersion.get());
         }
         return correctJDK;
+    }
+
+    public static boolean isCorrectJDK(Optional<Version> minVersion, Optional<Version> maxVersion) {
+        return isCorrectJDK(IDE_JDK_VERSION, minVersion, maxVersion);
     }
 
     /**
@@ -271,7 +275,7 @@ public final class JDK {
     private static int minor;
     private static int subminor;
     private static int update;
-    private static Version JDK_VERSION;
+    public static Version IDE_JDK_VERSION;
 
     // silently fall back to ridiculous defaults if something is crazily wrong...
     private static void initialize() {
@@ -337,6 +341,6 @@ public final class JDK {
             // ignore -- use defaults
         }
 
-        JDK_VERSION = new Version();
+        IDE_JDK_VERSION = new Version();
     }
 }

--- a/payara.tooling/src/org/netbeans/modules/payara/tooling/server/ServerTasks.java
+++ b/payara.tooling/src/org/netbeans/modules/payara/tooling/server/ServerTasks.java
@@ -37,7 +37,7 @@
  *
  * Contributor(s):
  */
-// Portions Copyright [2017-2018] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2017-2019] [Payara Foundation and/or its affiliates]
 
 package org.netbeans.modules.payara.tooling.server;
 
@@ -61,6 +61,8 @@ import org.netbeans.modules.payara.tooling.utils.OsUtils;
 import org.netbeans.modules.payara.tooling.utils.ServerUtils;
 import org.netbeans.modules.payara.tooling.utils.Utils;
 import org.netbeans.modules.payara.tooling.data.PayaraServer;
+import static org.netbeans.modules.payara.tooling.server.JDK.IDE_JDK_VERSION;
+import org.netbeans.modules.payara.tooling.server.JDK.Version;
 import org.netbeans.modules.payara.tooling.server.parser.JvmConfigReader.JvmOption;
 
 /**
@@ -184,10 +186,12 @@ public class ServerTasks {
                         METHOD, "readXMLerror"), domainXmlPath);
             }
         }
+
+        Version javaVersion = args.getJavaVersion() != null ? args.getJavaVersion() : IDE_JDK_VERSION;
         List<String> optList
                 = jvmConfigReader.getJvmOptions()
                         .stream()
-                        .filter(fullOption -> JDK.isCorrectJDK(fullOption.minVersion, fullOption.maxVersion))
+                        .filter(fullOption -> JDK.isCorrectJDK(javaVersion, fullOption.minVersion, fullOption.maxVersion))
                         .map(fullOption -> fullOption.option)
                         .collect(toList());
 


### PR DESCRIPTION
 This includes Payara Plugin compatibility with NetBeans IDE JDK 11 platform but Payara Server / Micro (5.184 or less) should explicit define the Java 8 home path.

**Explicit  Java Platform configuration**
**Payara Server :** Services > Servers > Payara Server > Properties > Java tab > Java Platform
**Payara Micro :** Project > Properties > Build > Compile > Java Platform